### PR TITLE
adding explicit handling of 'id' in example

### DIFF
--- a/src/actors/content/ContentActor.js
+++ b/src/actors/content/ContentActor.js
@@ -58,9 +58,10 @@ class ContentActor extends Actor {
   }
 
   async replay (payload, repository) {
-    if (typeof payload.meta.urlParams.contentId === 'undefined') return
-    const aggregate = await repository.get(payload.meta.urlParams.contentId)
-    return super.replay(aggregate, repository)
+    if (payload.meta.id || (payload.meta.urlParams && payload.meta.urlParams.contentId)) {
+      const aggregate = await repository.get(payload.meta.urlParams.contentId)
+      return super.replay(aggregate, repository)
+    }
   }
 }
 

--- a/src/actors/content/messages/CreateContentActor.js
+++ b/src/actors/content/messages/CreateContentActor.js
@@ -1,5 +1,4 @@
 // imports
-import uuidV4 from 'uuid/v4'
 import { parse, MessageActor, Schema } from 'hive-io'
 
 import ContentSchema from '../../../schemas/json/content/Content.json'
@@ -24,14 +23,14 @@ class CreateContentActor extends MessageActor {
   async perform (payload, modelInstance, repository) {
     if (typeof modelInstance !== 'undefined') throw new Error(`#${payload.meta.model}: ${modelInstance.id.id} already exists`)
 
-    if (typeof payload.data.id === 'undefined') payload.data.id = { id: uuidV4() }
+    payload.data.id = payload.meta.id
 
     const { command, event, model } = await super.perform(payload, modelInstance, repository)
 
     model.enabled = true
     model.edited = false
 
-    return { command, event, model }
+    return { id: payload.data.id, command, event, model }
   }
 }
 

--- a/src/actors/content/messages/DisableContentActor.js
+++ b/src/actors/content/messages/DisableContentActor.js
@@ -25,7 +25,7 @@ class DisableContentActor extends MessageActor {
 
     const { command, event, model } = await super.perform(payload, modelInstance, repository)
     model.enabled = false
-    return { command, event, model }
+    return { id: payload.meta.id, command, event, model }
   }
 }
 

--- a/src/actors/content/messages/EditContentActor.js
+++ b/src/actors/content/messages/EditContentActor.js
@@ -23,7 +23,7 @@ class EditContentActor extends MessageActor {
   async perform (payload, modelInstance, repository) {
     const { command, event, model } = await super.perform(payload, modelInstance, repository)
     model.edited = true
-    return { command, event, model }
+    return { id: payload.meta.id, command, event, model }
   }
 }
 

--- a/src/actors/content/messages/EnableContentActor.js
+++ b/src/actors/content/messages/EnableContentActor.js
@@ -25,7 +25,7 @@ class EnableContentActor extends MessageActor {
 
     const { command, event, model } = await super.perform(payload, modelInstance, repository)
     model.enabled = true
-    return { command, event, model }
+    return { id: payload.meta.id, command, event, model }
   }
 }
 

--- a/src/actors/post/PostEventActor.js
+++ b/src/actors/post/PostEventActor.js
@@ -53,7 +53,7 @@ class PostEventActor extends Actor {
       case 'View': {
         const { model } = await this[ACTORS].viewActor.perform(payload)
         ++modelInstance.viewed
-        return { command: null, event: model, model: modelInstance }
+        return { id: model.id, command: null, event: model, model: modelInstance }
       }
 
       default:

--- a/tst/actors/post/PostEventActor.spec.js
+++ b/tst/actors/post/PostEventActor.spec.js
@@ -2,7 +2,6 @@
 // imports
 import chai, { expect } from 'chai'
 import dirtyChai from 'dirty-chai'
-import { isUUID } from 'validator'
 import { Actor, Model } from 'hive-io'
 
 import PostEventActor from '../../../src/actors/post/PostEventActor'
@@ -11,18 +10,18 @@ chai.use(dirtyChai)
 
 // constants
 const createdPayload = {
-  data: { text: 'something' },
-  meta: { model: 'CreatedContent', version: 0 }
+  data: { text: 'something', id: { id: '1' } },
+  meta: { model: 'CreatedContent', version: 1, id: { id: '1' } }
 }
 const disabledPayload = {
-  meta: { model: 'DisabledContent', version: 1 }
+  meta: { model: 'DisabledContent', version: 2, id: { id: '1' } }
 }
 const editedPayload = {
   data: { text: 'something else' },
-  meta: { model: 'EditedContent', version: 2 }
+  meta: { model: 'EditedContent', version: 3, id: { id: '1' } }
 }
 const enabledPayload = {
-  meta: { model: 'EnabledContent', version: 3 }
+  meta: { model: 'EnabledContent', version: 4, id: { id: '1' } }
 }
 const viewPayload = {
   data: { id: { id: 'something' } },
@@ -57,7 +56,7 @@ describe('PostEventActor', () => {
         const { model } = await postEventActor.perform(createdPayload)
 
         expect(model).to.be.an.instanceof(Model)
-        expect(isUUID(model.id.id)).to.be.true()
+        expect(model.id.id).to.equal('1')
         expect(model.text).to.equal('something')
         expect(model.edited).to.be.false()
         expect(model.enabled).to.be.true()
@@ -67,7 +66,7 @@ describe('PostEventActor', () => {
       it('should throw an error for invalid data', async () => {
         const payload1 = {
           data: { text: null },
-          meta: { model: 'CreatedContent' }
+          meta: { model: 'CreatedContent', id: { id: '1' } }
         }
         try {
           await postEventActor.perform(payload1)
@@ -80,7 +79,7 @@ describe('PostEventActor', () => {
             id: { id: 1 },
             text: 'something'
           },
-          meta: { model: 'CreatedContent' }
+          meta: { model: 'CreatedContent', id: { id: '1' } }
         }
         try {
           await postEventActor.perform(payload2)
@@ -96,7 +95,7 @@ describe('PostEventActor', () => {
         const { model } = await postEventActor.perform(disabledPayload, modelInstance)
 
         expect(model).to.be.an.instanceof(Model)
-        expect(isUUID(model.id.id)).to.be.true()
+        expect(model.id.id).to.equal('1')
         expect(model.text).to.equal('something')
         expect(model.edited).to.be.false()
         expect(model.enabled).to.be.false()
@@ -120,7 +119,7 @@ describe('PostEventActor', () => {
         const { model } = await postEventActor.perform(editedPayload, modelInstance)
 
         expect(model).to.be.an.instanceof(Model)
-        expect(isUUID(model.id.id)).to.be.true()
+        expect(model.id.id).to.equal('1')
         expect(model.text).to.equal('something else')
         expect(model.edited).to.be.true()
         expect(model.enabled).to.be.false()
@@ -130,7 +129,7 @@ describe('PostEventActor', () => {
       it('should throw an error for invalid data', async () => {
         const payload = {
           data: { text: null },
-          meta: { model: 'EditedContent' }
+          meta: { model: 'EditedContent', id: { id: '1' } }
         }
         const modelInstance = await postEventActor.replay([createdPayload, disabledPayload])
 
@@ -148,7 +147,7 @@ describe('PostEventActor', () => {
         const { model } = await postEventActor.perform(enabledPayload, modelInstance)
 
         expect(model).to.be.an.instanceof(Model)
-        expect(isUUID(model.id.id)).to.be.true()
+        expect(model.id.id).to.equal('1')
         expect(model.text).to.equal('something else')
         expect(model.edited).to.be.true()
         expect(model.enabled).to.be.true()
@@ -172,7 +171,7 @@ describe('PostEventActor', () => {
         const { model } = await postEventActor.perform(viewPayload, modelInstance)
 
         expect(model).to.be.an.instanceof(Model)
-        expect(isUUID(model.id.id)).to.be.true()
+        expect(model.id.id).to.equal('1')
         expect(model.text).to.equal('something')
         expect(model.edited).to.be.false()
         expect(model.enabled).to.be.true()


### PR DESCRIPTION
also includes the additional responsibility on the `replay` method to query the repository for aggregate data and fixed unit tests to show more clearly how the Actors will integrate with their Docker service wrappers.