### PR TITLE
Update schema url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This example evolves the previous [hive-io-rest-example](https://www.npmjs.com/p
 ### Endpoints
 Once you get the app running using the [setup instructions](#getting-started) below, you can use the application from the following endpoint(s):
 - `http://localhost/posts (GET, POST)`
-    - POST [API JSON Schema](https://github.com/fnalabs/hive-js-rest-example/blob/master/src/schemas/json/Post.json)
+    - POST [API JSON Schema](https://github.com/fnalabs/hive-js-domain-example/blob/master/src/schemas/json/commands/CreateContent.json)
         ```
         {
           "text": "something"
         }
         ```
 - `http://localhost/posts/<postId> (GET, PATCH, DELETE)`
-    - PATCH [API JSON Schema](https://github.com/fnalabs/hive-js-rest-example/blob/master/src/schemas/json/Post.json)
+    - PATCH [API JSON Schema](https://github.com/fnalabs/hive-js-domain-example/blob/master/src/schemas/json/commands/EditContent.json)
         ```
         {
           "text": "something different"

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,9 +106,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
       "dev": true
     },
     "@babel/template": {
@@ -520,9 +520,9 @@
       }
     },
     "babel-eslint": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
-      "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.5.tgz",
+      "integrity": "sha512-TcdEGCHHquOPQOlH6Fe6MLwPWWWJLdeKhcGoLfOTShETpoH8XYWhjWJw38KCKaTca7c/EdxLolnbakixKxnXDg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.44",
@@ -788,9 +788,9 @@
       }
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1191,9 +1191,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "component-emitter": {
@@ -3029,9 +3029,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+      "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
     },
     "http-signature": {
@@ -3374,23 +3374,6 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3962,6 +3945,12 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -4006,9 +3995,9 @@
       }
     },
     "mongoose": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.1.6.tgz",
-      "integrity": "sha512-p8p/3Z2kfXViqawN1TV+cZ8XbHz6SsllkytKTog+CDWfCNObyGraHQlUuRv/9aYPNKiZfq6WWITgLpJLZW/o/A==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.1.7.tgz",
+      "integrity": "sha512-9zus8yEovPqLo3S2iXz2Dg9YJAo8xG7m161abqJbUNIqZYjvpPwjmWAs6ChZnxEUpTYFOve//ljvyA5V5D9sNw==",
       "requires": {
         "async": "2.6.1",
         "bson": "~1.0.5",
@@ -4081,9 +4070,9 @@
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -4091,7 +4080,6 @@
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
         "is-windows": "^1.0.2",
         "kind-of": "^6.0.2",
         "object.pick": "^1.3.0",
@@ -4608,21 +4596,21 @@
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-          "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
           "dev": true,
           "requires": {
-            "@babel/highlight": "7.0.0-beta.49"
+            "@babel/highlight": "7.0.0-beta.51"
           }
         },
         "@babel/generator": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-          "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+          "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/types": "7.0.0-beta.51",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.5",
             "source-map": "^0.5.0",
@@ -4630,38 +4618,38 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-          "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+          "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.49",
-            "@babel/template": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/helper-get-function-arity": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-          "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+          "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-          "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+          "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/highlight": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-          "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -4670,29 +4658,29 @@
           }
         },
         "@babel/template": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-          "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+          "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.49",
-            "@babel/parser": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
             "lodash": "^4.17.5"
           }
         },
         "@babel/traverse": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-          "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+          "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.49",
-            "@babel/generator": "7.0.0-beta.49",
-            "@babel/helper-function-name": "7.0.0-beta.49",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-            "@babel/parser": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/helper-function-name": "7.0.0-beta.51",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
             "debug": "^3.1.0",
             "globals": "^11.1.0",
             "invariant": "^2.2.0",
@@ -4700,9 +4688,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-          "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+          "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -5584,16 +5572,16 @@
           }
         },
         "istanbul-lib-instrument": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz",
-          "integrity": "sha512-ozQGtlIw+/a/F3n6QwWiuuyRAPp64+g2GVsKYsIez0sgIEzkU5ZpL2uZ5pmAzbEJ82anlRaPlOQZzkRXspgJyg==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.0.tgz",
+          "integrity": "sha512-Ie1LGWJVCFDDJKKH4g1ffpFcZTEXEd6ay5l9fE8539y4qPErJnzo4psnGzDH92tcKvdUDdbxrKySYIbt6zB9hw==",
           "dev": true,
           "requires": {
-            "@babel/generator": "7.0.0-beta.49",
-            "@babel/parser": "7.0.0-beta.49",
-            "@babel/template": "7.0.0-beta.49",
-            "@babel/traverse": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/traverse": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
             "istanbul-lib-coverage": "^2.0.0",
             "semver": "^5.5.0"
           },
@@ -7750,9 +7738,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.0.tgz",
-      "integrity": "sha512-MatciKXyM5pXMSoqd593MqTsItJNCkSSl53HJYeKR5wfsDdp2yljjUQJLfVwAWLoBNfx1HThteqygGQ0ZEpXpQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.1.tgz",
+      "integrity": "sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -8917,9 +8905,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   "dependencies": {
     "fluent-logger": "~2.7.0",
     "hive-io": "~2.0.0-rc.2",
-    "mongoose": "~5.1.6",
-    "uuid": "~3.2.1"
+    "mongoose": "~5.1.7",
+    "uuid": "~3.3.2"
   },
   "devDependencies": {
     "archiver": "~2.1.1",
     "babel-cli": "~6.26.0",
     "babel-core": "~6.26.3",
-    "babel-eslint": "~8.2.3",
+    "babel-eslint": "~8.2.5",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-istanbul": "~4.1.6",
     "babel-plugin-syntax-object-rest-spread": "~6.13.0",
@@ -56,7 +56,7 @@
     "nodemon": "~1.17.5",
     "nyc": "~12.0.2",
     "proxyquire": "~2.0.1",
-    "sinon": "~6.0.0",
+    "sinon": "~6.0.1",
     "standard": "~11.0.1",
     "uglify-es": "~3.3.9",
     "validator": "~10.4.0"

--- a/src/actors/messages/CreateContentActor.js
+++ b/src/actors/messages/CreateContentActor.js
@@ -10,8 +10,8 @@ import CreatedContentSchema from '../../schemas/json/events/CreatedContent.json'
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/Content': ContentSchema,
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/Content': ContentSchema,
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/messages/DisableContentActor.js
+++ b/src/actors/messages/DisableContentActor.js
@@ -9,8 +9,8 @@ import DisabledContentSchema from '../../schemas/json/events/DisabledContent.jso
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/Content': ContentSchema,
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/Content': ContentSchema,
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/messages/EditContentActor.js
+++ b/src/actors/messages/EditContentActor.js
@@ -10,8 +10,8 @@ import EditedContentSchema from '../../schemas/json/events/EditedContent.json'
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/Content': ContentSchema,
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/Content': ContentSchema,
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/messages/EnableContentActor.js
+++ b/src/actors/messages/EnableContentActor.js
@@ -9,8 +9,8 @@ import EnabledContentSchema from '../../schemas/json/events/EnabledContent.json'
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/Content': ContentSchema,
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/Content': ContentSchema,
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/messages/ViewContentActor.js
+++ b/src/actors/messages/ViewContentActor.js
@@ -6,7 +6,7 @@ import ViewedContentSchema from '../../schemas/json/events/ViewedContent.json'
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/post/PostCommandActor.js
+++ b/src/actors/post/PostCommandActor.js
@@ -22,8 +22,8 @@ const LOG_SYSTEM = Symbol('Log System')
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/Content': ContentSchema,
-  'https://hiveframework.io/api/v1/models/PostId': PostIdSchema
+  'https://hiveframework.io/api/v2/models/Content': ContentSchema,
+  'https://hiveframework.io/api/v2/models/PostId': PostIdSchema
 }
 
 /*

--- a/src/actors/post/PostQueryActor.js
+++ b/src/actors/post/PostQueryActor.js
@@ -16,7 +16,7 @@ const VIEW_SCHEMA = Symbol('View schema')
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/PostId': PostId
+  'https://hiveframework.io/api/v2/models/PostId': PostId
 }
 
 /*

--- a/src/schemas/json/Content.json
+++ b/src/schemas/json/Content.json
@@ -1,7 +1,7 @@
 {
   "title": "Content",
   "description": "Content value object used to create and modify Post content",
-  "$id": "https://hiveframework.io/api/v1/models/Content",
+  "$id": "https://hiveframework.io/api/v2/models/Content",
   "type": "object",
   "properties": {
     "text": {

--- a/src/schemas/json/Log.json
+++ b/src/schemas/json/Log.json
@@ -1,7 +1,7 @@
 {
   "title": "Log",
   "description": "value object that defines log format",
-  "$id": "https://hiveframework.io/api/v1/models/Log",
+  "$id": "https://hiveframework.io/api/v2/models/Log",
   "type": "object",
   "properties": {
     "actor": {

--- a/src/schemas/json/Post.json
+++ b/src/schemas/json/Post.json
@@ -1,24 +1,24 @@
 {
   "title": "Post",
   "description": "entity used for XA/SI to validate data from messages",
-  "$id": "https://hiveframework.io/api/v1/models/Post",
+  "$id": "https://hiveframework.io/api/v2/models/Post",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     },
     "text": {
       "description": "main Post Content",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/text"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/text"
     },
     "edited": {
       "description": "edited flag",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/edited"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/edited"
     },
     "enabled": {
       "description": "enabled flag",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/enabled"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/enabled"
     },
     "viewed": {
       "description": "total views of post content",

--- a/src/schemas/json/PostId.json
+++ b/src/schemas/json/PostId.json
@@ -1,7 +1,7 @@
 {
   "title": "PostId",
   "description": "Id value object for Posts",
-  "$id": "https://hiveframework.io/api/v1/models/PostId",
+  "$id": "https://hiveframework.io/api/v2/models/PostId",
   "type": "object",
   "properties": {
     "id": {

--- a/src/schemas/json/View.json
+++ b/src/schemas/json/View.json
@@ -1,12 +1,12 @@
 {
   "title": "View",
   "description": "value object that defines view logs",
-  "$id": "https://hiveframework.io/api/v1/models/View",
+  "$id": "https://hiveframework.io/api/v2/models/View",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/commands/CreateContent.json
+++ b/src/schemas/json/commands/CreateContent.json
@@ -1,16 +1,16 @@
 {
   "title": "CreateContent",
   "description": "command used to create Post Content",
-  "$id": "https://hiveframework.io/api/v1/commands/CreateContent",
+  "$id": "https://hiveframework.io/api/v2/commands/CreateContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     },
     "text": {
       "description": "main Post Content",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/text"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/text"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/commands/EditContent.json
+++ b/src/schemas/json/commands/EditContent.json
@@ -1,16 +1,16 @@
 {
   "title": "EditContent",
   "description": "command used to overwrite existing Post Content",
-  "$id": "https://hiveframework.io/api/v1/commands/EditContent",
+  "$id": "https://hiveframework.io/api/v2/commands/EditContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     },
     "text": {
       "description": "main Post Content",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/text"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/text"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/events/CreatedContent.json
+++ b/src/schemas/json/events/CreatedContent.json
@@ -1,16 +1,16 @@
 {
   "title": "CreatedContent",
   "description": "event used to log created Post Content",
-  "$id": "https://hiveframework.io/api/v1/events/CreatedContent",
+  "$id": "https://hiveframework.io/api/v2/events/CreatedContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     },
     "text": {
       "description": "main Post Content",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/text"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/text"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/events/DisabledContent.json
+++ b/src/schemas/json/events/DisabledContent.json
@@ -1,12 +1,12 @@
 {
   "title": "DisabledContent",
   "description": "event used to log disabled Post Content",
-  "$id": "https://hiveframework.io/api/v1/events/DisabledContent",
+  "$id": "https://hiveframework.io/api/v2/events/DisabledContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/events/EditedContent.json
+++ b/src/schemas/json/events/EditedContent.json
@@ -1,16 +1,16 @@
 {
   "title": "EditedContent",
   "description": "event used to log overwritten Post Content",
-  "$id": "https://hiveframework.io/api/v1/events/EditedContent",
+  "$id": "https://hiveframework.io/api/v2/events/EditedContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     },
     "text": {
       "description": "main Post Content",
-      "$id": "https://hiveframework.io/api/v1/models/Content#/properties/text"
+      "$id": "https://hiveframework.io/api/v2/models/Content#/properties/text"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/events/EnabledContent.json
+++ b/src/schemas/json/events/EnabledContent.json
@@ -1,12 +1,12 @@
 {
   "title": "EnabledContent",
   "description": "event used to log enabled Post Content",
-  "$id": "https://hiveframework.io/api/v1/events/EnabledContent",
+  "$id": "https://hiveframework.io/api/v2/events/EnabledContent",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/json/events/ViewedContent.json
+++ b/src/schemas/json/events/ViewedContent.json
@@ -1,12 +1,12 @@
 {
   "title": "ViewedContent",
   "description": "event used to capture log data for Post Content views",
-  "$id": "https://hiveframework.io/api/v1/models/View",
+  "$id": "https://hiveframework.io/api/v2/models/View",
   "type": "object",
   "properties": {
     "id": {
       "description": "Post Id Value Object",
-      "$id": "https://hiveframework.io/api/v1/models/PostId#/properties/id"
+      "$id": "https://hiveframework.io/api/v2/models/PostId#/properties/id"
     }
   },
   "additionalProperties": false,

--- a/tst/actors/ViewActor.spec.js
+++ b/tst/actors/ViewActor.spec.js
@@ -11,7 +11,7 @@ import ViewSchema from '../../src/schemas/json/View.json'
 
 // constants
 const REFS = {
-  'https://hiveframework.io/api/v1/models/PostId': PostId
+  'https://hiveframework.io/api/v2/models/PostId': PostId
 }
 
 chai.use(dirtyChai)


### PR DESCRIPTION
Fixing JSON Schema $id URLs so I can host both `hive-io-rest-example` and `hive-io-domain-example` schemas to illustrate both a Schema Registry example and evolving a product with the framework.